### PR TITLE
Fix CustomReminder sample crash caused by invalid TimeZone property type mapping

### DIFF
--- a/Reminders/CustomReminder/CustomReminder/Model/Event.cs
+++ b/Reminders/CustomReminder/CustomReminder/Model/Event.cs
@@ -9,8 +9,8 @@ namespace CustomReminder
         public bool IsAllDay { get; set; }
         public string EventName { get; set; } = string.Empty;
         public string Notes { get; set; } = string.Empty;
-        public string StartTimeZone { get; set; } = string.Empty;
-        public string EndTimeZone { get; set; } = string.Empty;
+        public TimeZoneInfo? StartTimeZone { get; set; }
+        public TimeZoneInfo? EndTimeZone { get; set; }
         public Brush? Color { get; set; }
         public object? RecurrenceId { get; set; } 
         public object? Id { get; set; }


### PR DESCRIPTION
Resolved the crash in the CustomReminder sample caused by an invalid cast exception:

Unable to cast object of type 'System.String' to type 'System.TimeZoneInfo'

Updated the appointment model to use the correct TimeZoneInfo type for the StartTimeZone and EndTimeZone properties, ensuring proper scheduler appointment mapping and preventing the runtime crash.

**Before changes:**
<img width="1919" height="1010" alt="Screenshot 2026-07-20 160428" src="https://github.com/user-attachments/assets/a18160a2-ae3a-4607-a068-4fa71c2e6e3e" />


**After changes:**
<img width="1421" height="730" alt="Screenshot 2026-07-20 161336" src="https://github.com/user-attachments/assets/5acf5b9d-af53-46b8-b03f-5a8659217677" />
